### PR TITLE
fix(tools): Use as_posix() for cross-platform paths

### DIFF
--- a/tests/test_auto_blueprint_full.py
+++ b/tests/test_auto_blueprint_full.py
@@ -1,0 +1,31 @@
+import unittest
+import json
+import sys
+from pathlib import Path
+
+# Add the 'tools' directory to the Python path to allow direct import of modules within it
+tools_dir = Path(__file__).resolve().parent.parent / 'tools'
+sys.path.insert(0, str(tools_dir))
+
+from auto_blueprint_full import build_blueprint
+
+class TestAutoBlueprintFull(unittest.TestCase):
+
+    def test_source_file_path_format(self):
+        # Create a dummy file path
+        dummy_file = Path("framework/test_document.txt")
+
+        # Dummy content for the file
+        raw_text = "This is a test document."
+
+        # Generate the blueprint
+        blueprint = build_blueprint(dummy_file, raw_text)
+
+        # Get the source file path from the blueprint
+        source_file_path = blueprint.get("metadata", {}).get("source_file")
+
+        # Check if the path is in the correct posix format
+        self.assertEqual(source_file_path, "framework/test_document.txt")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/auto_blueprint_full.py
+++ b/tools/auto_blueprint_full.py
@@ -126,7 +126,7 @@ def build_blueprint(src: Path, raw_text: str) -> dict:
         "metadata": {
             "author": "NamoVerse Engine",
             "language": "en",
-            "source_file": str(src),
+            "source_file": src.as_posix(),
             "last_updated": str(datetime.date.today()),
             "pipeline": "auto-blueprint-full"
         }


### PR DESCRIPTION
The 'auto_blueprint_full.py' script was using str() to convert a pathlib.Path object to a string for the 'source_file' metadata field. This created inconsistent path separators on Windows vs. POSIX systems.

This commit fixes the issue by using .as_posix() to ensure all generated paths use forward slashes, making them consistent and portable.

A new test case was added to verify the fix and ensure the path is always in the correct format.